### PR TITLE
Support lower case nucleotides in `IPA_finder.pl`

### DIFF
--- a/src/IPA_finder.pl
+++ b/src/IPA_finder.pl
@@ -36,7 +36,7 @@ if (defined($help) || ! $fasta_file){
 my %seq = %{read_fasta ($fasta_file)};
 
 foreach my $chr (keys %seq){
-    my $seq = $seq{$chr};
+    my $seq = uc($seq{$chr});
     my $splus=$seq;
     $splus=~tr/ATGCN/10000/;
     my @plus  = @{find_matches ($splus,0)};


### PR DESCRIPTION
Some references use `acgt` instead of `ACGT` at some places. I think this is used for maskin and the likes.
Anyhow, currently, all tools used in SCALPEL handle this fine, except for `IPA_finder.pl`, which fails with a rather cryptic error message. This PR fixes this by converting the inuput to upper case before screening for IPAs.

@Franzx7: This fixes the issue Akshay talked to you about.